### PR TITLE
Move [at]types to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "url": "https://github.com/ukyo/tiny-commit-walker/issues"
   },
   "dependencies": {
-    "@types/lru-cache": "^4.0.0",
-    "@types/node": "^8.0.10",
     "lru-cache": "^4.1.1",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {
+    "@types/lru-cache": "^4.0.0",
+    "@types/node": "^8.0.10",
     "ava": "^0.20.0",
     "npm-run-all": "^4.0.2",
     "touch": "^3.1.0",


### PR DESCRIPTION
Should not add `@types/xxx` to dependencies, because they are not needed for users this package.